### PR TITLE
Add CI/CD workflow and cleanup documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Run linter
+      run: npm run lint
+    
+    - name: Run type check
+      run: npm run type-check
+    
+    - name: Run tests
+      run: npm test -- --coverage
+    
+    - name: Build application
+      run: npm run build
+      env:
+        NEXT_PUBLIC_API_URL: http://localhost:8000
+        NEXT_PUBLIC_AUTH_URL: http://localhost:8004
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/pyairtablemcp/pyairtable-frontend:latest
+          ghcr.io/pyairtablemcp/pyairtable-frontend:${{ github.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# Testing
+/coverage
+
+# Next.js
+/.next/
+/out/
+
+# Production
+/build
+/dist
+
+# Misc
+.DS_Store
+*.pem
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Local env files
+.env*.local
+.env
+
+# Vercel
+.vercel
+
+# TypeScript
+*.tsbuildinfo
+next-env.d.ts
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+*~
+
+# OS
+Thumbs.db

--- a/CLEANUP_STATUS.md
+++ b/CLEANUP_STATUS.md
@@ -1,0 +1,45 @@
+# PyAirtable Frontend - Cleanup Status
+
+## Date: August 10, 2025
+
+## Repository Status: ✅ Clean
+
+This repository was reviewed as part of the PyAirtableMCP organization cleanup initiative.
+
+## Findings
+- Repository is already well-organized (80KB total)
+- No node_modules or build artifacts present
+- Modern Next.js 15 setup with TypeScript
+- Comprehensive dependencies properly managed
+- Documentation is thorough and up-to-date
+
+## Actions Taken
+1. Added comprehensive .gitignore file
+2. Created GitHub Actions CI/CD workflow
+3. Added this cleanup status document
+
+## Repository Structure
+```
+pyairtable-frontend/
+├── src/
+│   ├── app/           # Next.js 15 app router pages
+│   ├── components/    # React components
+│   ├── hooks/         # Custom React hooks
+│   ├── lib/           # Utilities and helpers
+│   ├── stores/        # Zustand state management
+│   └── types/         # TypeScript definitions
+├── public/            # Static assets
+├── .github/           # GitHub Actions workflows
+└── config files       # Next.js, TypeScript, Tailwind configs
+```
+
+## Tech Stack
+- **Framework**: Next.js 15 with App Router
+- **Language**: TypeScript
+- **Styling**: Tailwind CSS + shadcn/ui
+- **State**: Zustand + TanStack Query
+- **Testing**: Vitest + React Testing Library
+- **CI/CD**: GitHub Actions
+
+## No Further Cleanup Needed
+This repository is already optimized and production-ready.


### PR DESCRIPTION
## Summary
Added CI/CD pipeline and cleanup documentation for the frontend repository.

## Changes
- Added comprehensive .gitignore file
- Created GitHub Actions CI/CD workflow with:
  - Multi-version Node.js testing (18.x, 20.x)
  - Linting, type checking, and testing
  - Docker image building and pushing to GitHub Container Registry
- Added CLEANUP_STATUS.md documenting repository state

## Findings
- Repository already clean and well-organized (80KB)
- Modern Next.js 15 setup with TypeScript
- No cleanup needed beyond adding CI/CD

Part of PyAirtableMCP organization cleanup initiative.